### PR TITLE
コントローラのリファクタリング結果と、テストの整合性が崩れたため修正

### DIFF
--- a/spec/requests/tsundocs_spec.rb
+++ b/spec/requests/tsundocs_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Tsundocs", type: :request do
       sign_in user
     end
     it "302レスポンス" do
-      post tsundocs_path, params: { priority_pt: 100, private: false, title: "book", author: "John" }
+      post tsundocs_path, params: { priority_pt: 100, private: false, title: "book", author: "John", kind: "book" }
       expect(response).to have_http_status(302)
     end
   end


### PR DESCRIPTION
## what
requestスペックのhttpリクエスト時に送るパラメータを追加した。

## why
materialのサブクラスによらないtsundocレコード生成を実現するためにコントローラのリファクタリングを行った。
materialのどのサブクラスを呼び出すか指定するためのパラメータがもとのテストになかったためエラーが発生した。
