### PR TITLE
ログイン時、トップページに自身の積ん読リストを表示する機能を追加

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,5 +1,9 @@
 class RootController < ApplicationController
   def index
-    @user = User.new
+    if user_signed_in?
+      @tsundocs = Tsundoc.list_owned_by(current_user)
+    else
+      @user = User.new
+    end
   end
 end

--- a/app/helpers/book_helper.rb
+++ b/app/helpers/book_helper.rb
@@ -1,0 +1,16 @@
+module BookHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Context
+  def display_book
+    keys = %w(title author)
+
+    html = ""
+
+    keys.each do |key|
+      html += tag.a send(:"#{key}")
+      html += tag.a " "
+    end
+
+    html.html_safe
+  end
+end

--- a/app/helpers/tsundoc_helper.rb
+++ b/app/helpers/tsundoc_helper.rb
@@ -1,0 +1,17 @@
+module TsundocHelper
+  include ActionView::Helpers::TagHelper
+  include ActionView::Context
+  def display_tsundoc
+    keys = %w(status priority_pt)
+
+    html = ""
+
+    keys.each do |key|
+      html += tag.a "#{key}: "
+      html += tag.a send(:"#{key}")
+      html += tag.a " "
+    end
+
+    html.html_safe
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,10 +1,6 @@
 class Book < ApplicationRecord
+  include BookHelper
   belongs_to :material
   delegate :tsundoc, to: :material
 
-  # ↓これをmaterialクラスに移管する
-  # def self.create(book_params)
-  #   material = Material.create
-  #   super(book_params.merge(material_id: material.id))
-  # end
 end

--- a/app/models/material.rb
+++ b/app/models/material.rb
@@ -7,4 +7,8 @@ class Material < ApplicationRecord
     material = create
     const_get(kind.classify).create(params.merge(material_id: material.id))
   end
+
+  def get_tsundoc_product(kind = "book")
+    send(kind.downcase)
+  end
 end

--- a/app/models/tsundoc.rb
+++ b/app/models/tsundoc.rb
@@ -1,4 +1,15 @@
 class Tsundoc < ApplicationRecord
+  include TsundocHelper
   belongs_to :material
   belongs_to :tsundoc_list
+
+  def self.list_owned_by(user)
+    TsundocList.owned_by(user).tsundocs
+  end
+
+  def get_tsundoc_product(kind = "book")
+    material.get_tsundoc_product(kind)
+  end
+
+
 end

--- a/app/models/tsundoc_list.rb
+++ b/app/models/tsundoc_list.rb
@@ -1,4 +1,8 @@
 class TsundocList < ApplicationRecord
   belongs_to :user
   has_many :tsundocs
+
+  def self.owned_by(user)
+    user.tsundoc_list
+  end
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,30 +1,33 @@
 <h1>積んどく？</h1>
 <div>
-  <p>
-    <% if user_signed_in? %>
-
-    <% else %>
-      <h2>ログイン</h2>
-      <%= form_for(@user, as: :user, url: session_path(:user)) do |f| %>
-        <div class="field">
-          <%= f.label :email %><br />
-          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-        </div>
-
-        <div class="field">
-          <%= f.label :password %><br />
-          <%= f.password_field :password, autocomplete: "current-password" %>
-        </div>
-
-        <div class="field">
-          <%= f.check_box :remember_me %>
-          <%= f.label :remember_me %>
-        </div>
-
-        <div class="actions">
-          <%= f.submit "Log in" %>
-        </div>
-      <% end %>
+  <% if user_signed_in? %>
+    <% @tsundocs.each do |tsundoc| %>
+      <div>
+        <%= tsundoc.get_tsundoc_product.display_book %>
+        <%= tsundoc.display_tsundoc %>
+      </div>
     <% end %>
-  </p>
+  <% else %>
+    <h2>ログイン</h2>
+    <%= form_for(@user, as: :user, url: session_path(:user)) do |f| %>
+      <div class="field">
+        <%= f.label :email %><br />
+        <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      </div>
+
+      <div class="field">
+        <%= f.label :password %><br />
+        <%= f.password_field :password, autocomplete: "current-password" %>
+      </div>
+
+      <div class="field">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me %>
+      </div>
+
+      <div class="actions">
+        <%= f.submit "Log in" %>
+      </div>
+    <% end %>
+  <% end %>
 </div>


### PR DESCRIPTION
## what
積ん読リストを表示する機能を追加。各、積ん読レコードごとの表示はヘルパーに分離して、積ん読モデル、bookモデルごとにインクルード。

## why
自分の積ん読リストを閲覧できるようにするため。
他人のはどうでも良くて、自分のを真っ先にみたいと思ったのでトップページに追加

## note
トップページ用にroot#indexコントローラを用意したが、普通にtsundoc#indexでも良いのでは？と思った。
→が、ログイン機能もあるからrailsのcrudの名前にするの微妙？
→そのままで良い