### PR TITLE
トップページの積ん読リスト表示を初回時に本の積ん読のみ表示する仕様に変更。

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,7 +1,8 @@
 class RootController < ApplicationController
   def index
     if user_signed_in?
-      @tsundocs = Tsundoc.list_owned_by(current_user)
+      tsundoc_list = current_user.tsundoc_list
+      @tsundocs = tsundoc_list.gets_tsundocs_of(params[:tsundocable_type] || "Book")
     else
       @user = User.new
     end

--- a/app/models/tsundoc.rb
+++ b/app/models/tsundoc.rb
@@ -6,4 +6,8 @@ class Tsundoc < ApplicationRecord
   def self.list_owned_by(user)
     TsundocList.owned_by(user).tsundocs
   end
+
+  def is?(checked_type)
+    tsundocable_type == checked_type
+  end
 end

--- a/app/models/tsundoc_list.rb
+++ b/app/models/tsundoc_list.rb
@@ -5,4 +5,8 @@ class TsundocList < ApplicationRecord
   def self.owned_by(user)
     user.tsundoc_list
   end
+
+  def gets_tsundocs_of(tsundocable_type)
+    tsundocs.find_all{|t| t.is?(tsundocable_type)}
+  end
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,6 +1,8 @@
 <h1>積んどく？</h1>
 <div>
   <% if user_signed_in? %>
+    <%=link_to "本のリスト", root_path(tsundocable_type: "Book") %>
+    <%=link_to "映画のリスト", root_path(tsundocable_type: "Movie") %>
     <% @tsundocs.each do |tsundoc| %>
       <div>
         <%= tsundoc.tsundocable.display %>

--- a/spec/factories/books.rb
+++ b/spec/factories/books.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :book do
-    sequence(:title) { |n| "タイトル#{n}" }
-    sequence(:author) { |n| "作者#{n}" }
+    sequence(:title) { |n| "本のタイトル#{n}" }
+    sequence(:author) { |n| "本の作者#{n}" }
   end
 end

--- a/spec/factories/movie.rb
+++ b/spec/factories/movie.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :movie do
-    sequence(:title) { |n| "タイトル#{n}" }
+    sequence(:title) { |n| "映画のタイトル#{n}" }
   end
 end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -5,27 +5,62 @@ RSpec.describe "Roots", type: :request do
   let(:tsundoc_list) { FactoryBot.create(:tsundoc_list, user: user) }
 
   describe "GET#index" do
+    let!(:book_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_book, tsundoc_list: tsundoc_list) }
+    let!(:movie_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_movie, tsundoc_list: tsundoc_list) }
+    let(:book_titles) { book_tsundocs.map{|t| t.tsundocable.title} }
+    let(:movie_titles) { movie_tsundocs.map{|t| t.tsundocable.title} }
+
     before do
       sign_in user
     end
 
     subject { response.body }
 
-    context "本を登録した場合tsundocリストがすべて表示されている" do
-      let!(:tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_book, tsundoc_list: tsundoc_list) }
-      let(:book_title_array) { tsundocs.map{|t| t.tsundocable.title} }
-      it "tsundocリストがすべて表示されている" do
-        get root_path
-        is_expected.to include *book_title_array
+    context "初回表示の場合" do
+      before { get root_path }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストがすべて表示される" do
+        is_expected.to include *book_titles
+      end
+
+      it "映画のtsundocリストは表示されない" do
+        is_expected.to_not include *movie_titles
       end
     end
 
-    context "映画を登録した場合" do
-      let!(:tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_movie, tsundoc_list: tsundoc_list) }
-      let(:movie_title_array) { tsundocs.map{|t| t.tsundocable.title} }
-      it "tsundocリストがすべて表示されている" do
-        get root_path
-        is_expected.to include *movie_title_array
+    context "本のリストを表示する場合" do
+      before { get root_path(tsundocable_type: "Book") }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストは表示される" do
+        is_expected.to include *book_titles
+      end
+
+      it "映画のtsundocリストは表示されない" do
+        is_expected.to_not include *movie_titles
+      end
+    end
+
+    context "映画のリストを表示する場合" do
+      before { get root_path(tsundocable_type: "Movie") }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストは表示されない" do
+        is_expected.to_not include *book_titles
+      end
+
+      it "映画のtsundocリストは表示される" do
+        is_expected.to include *movie_titles
       end
     end
   end


### PR DESCRIPTION
## what
積ん読対象ごとにリストアップするメソッドを追加
↑で追加したメソッドをトップページ用のコントローラ中で呼び出し

## why
本と映画の切り替え機能を追加。
