### PR TITLE
リファクタリング、次の実装のための変更

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -4,7 +4,8 @@ class TagsController < ApplicationController
   end
 
   def create
-    if @tag = Tag.factory(tag_params)
+    @tag = Tag.new(tag_params)
+    if @tag.save
       redirect_to root_path
     else
       render :new
@@ -14,7 +15,7 @@ class TagsController < ApplicationController
   private
 
   def tag_params
-    params.require(:tag).permit(:name, :type).merge(user_id: current_user.id)
+    params.permit(:name, :type).merge(user_id: current_user.id)
   end
 end
 

--- a/app/controllers/tsundocs_controller.rb
+++ b/app/controllers/tsundocs_controller.rb
@@ -7,6 +7,11 @@
 # end
 
 class TsundocsController < ApplicationController
+  def index
+    tsundoc_list = current_user.tsundoc_list
+    @tsundocs = tsundoc_list.gets_tsundocs_of(params[:tsundocable_type] || "Book")
+  end
+
   def new
     @tsundoc = Tsundoc.new
   end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,7 +3,8 @@ class Tag < ApplicationRecord
   belongs_to :user
   validates :name, presence: true
 
-  def self.factory(params)
+  def self.create_by_type(params)
+    return raise "Forget send tag type ??" if params[:type].nil?
     # レコード作成の成否をbooleanで返すため、createではなくnew+saveを用いる
     const_get(params[:type]).new(params).save
   end

--- a/app/models/tsundoc.rb
+++ b/app/models/tsundoc.rb
@@ -2,12 +2,21 @@ class Tsundoc < ApplicationRecord
   include TsundocHelper
   belongs_to :tsundoc_list
   belongs_to :tsundocable, polymorphic: true
+  has_many :taggings
+  has_many :tags, through: :taggings
+
 
   def self.list_owned_by(user)
     TsundocList.owned_by(user).tsundocs
   end
 
+  def self.tags_sort
+    each{|t| t.tagging}
+  end
+
+
   def is?(checked_type)
     tsundocable_type == checked_type
   end
+
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,6 +13,7 @@
     <div>
       <%=link_to "トップページ", root_path %>
       <% if user_signed_in? %>
+        <%=link_to "リスト表示", tsundocs_path%>
         <%=link_to "積ん読(本)を登録", new_book_path %>
         <%=link_to "積ん読(映画)を登録", new_movie_path %>
         <%=link_to "タグを作成", new_tag_path %>

--- a/app/views/tags/new.html.erb
+++ b/app/views/tags/new.html.erb
@@ -1,6 +1,6 @@
 <h1>タグの作成</h1>
 <div>
-  <%= form_with model: @tag, method: :post, local: true do |f| %>
+  <%= form_with url: tags_path, method: :post, local: true do |f| %>
     <div>
       <div>
         タグ

--- a/app/views/tsundocs/index.html.erb
+++ b/app/views/tsundocs/index.html.erb
@@ -1,0 +1,11 @@
+<h1>積んどく？</h1>
+<div>
+  <%=link_to "本のリスト", tsundocs_path(tsundocable_type: "Book") %>
+  <%=link_to "映画のリスト", tsundocs_path(tsundocable_type: "Movie") %>
+  <% @tsundocs.each do |tsundoc| %>
+    <div>
+      <%= tsundoc.tsundocable.display %>
+      <%= tsundoc.display_tsundoc %>
+    </div>
+  <% end %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'users/registrations' }
   root 'root#index'
 
-  resources :tsundocs, only: [:new, :create]
+  resources :tsundocs, only: [:index, :new, :create]
   resources :books, only: [:new, :create]
   resources :movies, only: [:new, :create]
   resources :tags, only: [:new, :create]

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Tag, type: :model do
   describe 'factory' do
     let(:user) { FactoryBot.create(:user) }
-    before { Tag.factory(params) }
+    before { Tag.create_by_type(params) }
 
     context "本のタグのパラメータを入力した場合" do
     let(:params) { FactoryBot.attributes_for(:tag, :for_book, user_id: user.id) }

--- a/spec/requests/tags_spec.rb
+++ b/spec/requests/tags_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Tags", type: :request do
   end
 
   describe "POST#create" do
-    subject { post tags_path, params: { tag: { name: tag_name, type: "BookTag" }} }
+    subject { post tags_path, params: { name: tag_name, type: "BookTag" } }
 
     context "正常なパラメータを渡した場合" do
       let(:tag_name) { "tag" }

--- a/spec/requests/tsundocs_spec.rb
+++ b/spec/requests/tsundocs_spec.rb
@@ -1,0 +1,67 @@
+require 'rails_helper'
+
+RSpec.describe "Tsundocs", type: :request do
+  let(:user) { FactoryBot.create(:user) }
+  let(:tsundoc_list) { FactoryBot.create(:tsundoc_list, user: user) }
+
+  describe "GET#index" do
+    let!(:book_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_book, tsundoc_list: tsundoc_list) }
+    let!(:movie_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_movie, tsundoc_list: tsundoc_list) }
+    let(:book_titles) { book_tsundocs.map{|t| t.tsundocable.title} }
+    let(:movie_titles) { movie_tsundocs.map{|t| t.tsundocable.title} }
+
+    before do
+      sign_in user
+    end
+
+    subject { response.body }
+
+    context "初回表示の場合" do
+      before { get root_path }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストがすべて表示される" do
+        is_expected.to include *book_titles
+      end
+
+      it "映画のtsundocリストは表示されない" do
+        is_expected.to_not include *movie_titles
+      end
+    end
+
+    context "本のリストを表示する場合" do
+      before { get root_path(tsundocable_type: "Book") }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストは表示される" do
+        is_expected.to include *book_titles
+      end
+
+      it "映画のtsundocリストは表示されない" do
+        is_expected.to_not include *movie_titles
+      end
+    end
+
+    context "映画のリストを表示する場合" do
+      before { get root_path(tsundocable_type: "Movie") }
+
+      it "200レスポンス" do
+        expect(response).to have_http_status(200)
+      end
+
+      it "本のtsundocリストは表示されない" do
+        is_expected.to_not include *book_titles
+      end
+
+      it "映画のtsundocリストは表示される" do
+        is_expected.to include *movie_titles
+      end
+    end
+  end
+end


### PR DESCRIPTION
## what
- tag生成機能のリファクタリング
- 現在のリスト表示を退避
- 上記に合わせてテストも変更、移動

## why
- リスト表示の対比→トップページにタグソート表示を実装するため、