### PR TITLE
トップページの積ん読表示をタグを見出しとしたリストに変更。

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,8 +1,7 @@
 class RootController < ApplicationController
   def index
     if user_signed_in?
-      tsundoc_list = current_user.tsundoc_list
-      @tsundocs = tsundoc_list.gets_tsundocs_of(params[:tsundocable_type] || "Book")
+      @tags = current_user.get_associated_objects(params[:tag_type] || "BookTag")
     else
       @user = User.new
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -9,5 +9,4 @@ class Tag < ApplicationRecord
     # レコード作成の成否をbooleanで返すため、createではなくnew+saveを用いる
     const_get(params[:type]).new(params).save
   end
-
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,6 @@
 class Tag < ApplicationRecord
-  has_many :tagging
+  has_many :taggings
+  has_many :tsundocs, through: :taggings
   belongs_to :user
   validates :name, presence: true
 
@@ -8,4 +9,5 @@ class Tag < ApplicationRecord
     # レコード作成の成否をbooleanで返すため、createではなくnew+saveを用いる
     const_get(params[:type]).new(params).save
   end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   has_one :tsundoc_list
   has_many :book_tags
   has_many :movie_tags
+
+  def get_associated_objects(class_name)
+    send(class_name.underscore.pluralize)
+  end
 end

--- a/app/views/root/index.html.erb
+++ b/app/views/root/index.html.erb
@@ -1,13 +1,17 @@
 <h1>積んどく？</h1>
 <div>
   <% if user_signed_in? %>
-    <%=link_to "本のリスト", root_path(tsundocable_type: "Book") %>
-    <%=link_to "映画のリスト", root_path(tsundocable_type: "Movie") %>
-    <% @tsundocs.each do |tsundoc| %>
+    <%=link_to "本のリスト", root_path(tag_type: "BookTag") %>
+    <%=link_to "映画のリスト", root_path(tag_type: "MovieTag") %>
+    <% @tags.each do |tag| %>
       <div>
-        <%= tsundoc.tsundocable.display %>
-        <%= tsundoc.display_tsundoc %>
-      </div>
+        <h2><%= tag.name %></h2>
+      <% tag.tsundocs.each do |tsundoc| %>
+        <div>
+          <%= tsundoc.tsundocable.display %>
+          <%= tsundoc.display_tsundoc %>
+        </div>
+      <% end %>
     <% end %>
   <% else %>
     <h2>ログイン</h2>

--- a/spec/factories/taggings.rb
+++ b/spec/factories/taggings.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :tagging do
+  end
+end

--- a/spec/factories/tsundocs.rb
+++ b/spec/factories/tsundocs.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :tsundoc do
+    transient { user { User.new } }
+
     sequence(:priority_pt){ |n| 100 + n }
     status { 0 }
 
@@ -9,6 +11,20 @@ FactoryBot.define do
 
     trait :with_movie do
       association :tsundocable, factory: :movie
+    end
+
+    trait :with_book_tag do
+      after(:create) do |tsundoc, e|
+        tag = FactoryBot.create(:tag, :for_book, user: e.user)
+        FactoryBot.create(:tagging, tsundoc: tsundoc, tag: tag)
+      end
+    end
+
+    trait :with_movie_tag do
+      after(:create) do |tsundoc, e|
+        tag = FactoryBot.create(:tag, :for_movie, user: e.user)
+        FactoryBot.create(:tagging, tsundoc: tsundoc, tag: tag)
+      end
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe User, type: :model do
       context "本のタグ" do
         let!(:tags) { FactoryBot.create_list(:tag, 5, :for_book, user: user) }
         let!(:book_tags) { tags.map{ |t| t.becomes(BookTag) } }
-
         subject { user.get_associated_objects("BookTag") }
 
         it "正しいオブジェクトが返される" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  describe 'get_associated_objects' do
+    let(:user) { FactoryBot.create(:user) }
+
+
+    context "クラス名を渡すと、ユーザに紐づく当該クラスのデータ配列が返される" do
+      context "本のタグ" do
+        let!(:tags) { FactoryBot.create_list(:tag, 5, :for_book, user: user) }
+        let!(:book_tags) { tags.map{ |t| t.becomes(BookTag) } }
+
+        subject { user.get_associated_objects("BookTag") }
+
+        it "正しいオブジェクトが返される" do
+          is_expected.to eq(book_tags)
+        end
+      end
+
+      context "映画のタグ" do
+        let!(:tags) { FactoryBot.create_list(:tag, 5, :for_movie, user: user) }
+        let!(:movie_tags) { tags.map{ |t| t.becomes(MovieTag) } }
+        subject { user.get_associated_objects("MovieTag") }
+
+        it "正しいオブジェクトが返される" do
+          is_expected.to eq(movie_tags)
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/root_spec.rb
+++ b/spec/requests/root_spec.rb
@@ -5,10 +5,12 @@ RSpec.describe "Roots", type: :request do
   let(:tsundoc_list) { FactoryBot.create(:tsundoc_list, user: user) }
 
   describe "GET#index" do
-    let!(:book_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_book, tsundoc_list: tsundoc_list) }
-    let!(:movie_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_movie, tsundoc_list: tsundoc_list) }
+    let!(:book_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_book, :with_book_tag, user: user, tsundoc_list: tsundoc_list) }
+    let!(:movie_tsundocs) { FactoryBot.create_list(:tsundoc, 5, :with_movie, :with_movie_tag, user: user, tsundoc_list: tsundoc_list) }
     let(:book_titles) { book_tsundocs.map{|t| t.tsundocable.title} }
     let(:movie_titles) { movie_tsundocs.map{|t| t.tsundocable.title} }
+    let(:book_tag_names) { book_tsundocs.map{|t| t.tags.first.name } }
+    let(:movie_tag_names) { movie_tsundocs.map{|t| t.tags.first.name } }
 
     before do
       sign_in user
@@ -30,10 +32,18 @@ RSpec.describe "Roots", type: :request do
       it "映画のtsundocリストは表示されない" do
         is_expected.to_not include *movie_titles
       end
+
+      it "本のtagがすべて表示される" do
+        is_expected.to include *book_tag_names
+      end
+
+      it "映画のtagは表示されない" do
+        is_expected.to_not include *movie_tag_names
+      end
     end
 
     context "本のリストを表示する場合" do
-      before { get root_path(tsundocable_type: "Book") }
+      before { get root_path(tag_type: "BookTag") }
 
       it "200レスポンス" do
         expect(response).to have_http_status(200)
@@ -46,10 +56,18 @@ RSpec.describe "Roots", type: :request do
       it "映画のtsundocリストは表示されない" do
         is_expected.to_not include *movie_titles
       end
+
+      it "本のtagがすべて表示される" do
+        is_expected.to include *book_tag_names
+      end
+
+      it "映画のtagは表示されない" do
+        is_expected.to_not include *movie_tag_names
+      end
     end
 
     context "映画のリストを表示する場合" do
-      before { get root_path(tsundocable_type: "Movie") }
+      before { get root_path(tag_type: "MovieTag") }
 
       it "200レスポンス" do
         expect(response).to have_http_status(200)
@@ -61,6 +79,14 @@ RSpec.describe "Roots", type: :request do
 
       it "映画のtsundocリストは表示される" do
         is_expected.to include *movie_titles
+      end
+
+      it "本のtagは表示されない" do
+        is_expected.to_not include *book_tag_names
+      end
+
+      it "映画のtagはすべて表示される" do
+        is_expected.to include *movie_tag_names
       end
     end
   end

--- a/spec/requests/tsundocs_spec.rb
+++ b/spec/requests/tsundocs_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Tsundocs", type: :request do
     subject { response.body }
 
     context "初回表示の場合" do
-      before { get root_path }
+      before { get tsundocs_path }
 
       it "200レスポンス" do
         expect(response).to have_http_status(200)
@@ -33,7 +33,7 @@ RSpec.describe "Tsundocs", type: :request do
     end
 
     context "本のリストを表示する場合" do
-      before { get root_path(tsundocable_type: "Book") }
+      before { get tsundocs_path(tsundocable_type: "Book") }
 
       it "200レスポンス" do
         expect(response).to have_http_status(200)
@@ -49,7 +49,7 @@ RSpec.describe "Tsundocs", type: :request do
     end
 
     context "映画のリストを表示する場合" do
-      before { get root_path(tsundocable_type: "Movie") }
+      before { get tsundocs_path(tsundocable_type: "Movie") }
 
       it "200レスポンス" do
         expect(response).to have_http_status(200)


### PR DESCRIPTION
## what
- userモデルにクラス名からhas_many関連を呼び出すメソッドを追加
- indexページの表示をtagに紐づく形に変更

## why
- userモデルのメソッド
  - viewファイルからアソシエーション先を動的に決める場合、このアプリ開発全体を通してクラス名を渡すことに統一したいから
- indexページの表示
  - tagリスト表示の場合、コントローラでuserに紐づくタグのリストを取得し、タグからアソシエーションを用いて積ん読リストを呼び出すほうがスマートに書けたため。 