### PR TITLE
積ん読対象コントローラにてsuperで呼び出していたコードをモジュール化

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -1,14 +1,13 @@
 class BooksController < TsundocsController
+  include TsundocablesControllerModule
+
   def new
     @tsundoc = Tsundoc.new
     @tags = current_user.book_tags
   end
 
   def create
-    ApplicationRecord.transaction do
-      @tsundocable = Book.create(book_params)
-      super
-    end
+    @tsundocable = Book.create(book_params)
     redirect_to root_path
   end
 

--- a/app/controllers/concerns/tsundocables_controller_module.rb
+++ b/app/controllers/concerns/tsundocables_controller_module.rb
@@ -1,0 +1,26 @@
+module TsundocablesControllerModule
+  extend ActiveSupport::Concern
+
+  included do
+    after_action :create_tsundoc, only: :create
+  end
+
+  def create_tsundoc
+    @tsundoc = Tsundoc.create(tsundoc_params)
+    @taggings = Tagging.factory(tagging_params[:tag_ids], tagging_params[:tsundoc_id])
+  end
+
+  private
+
+  def tsundoc_params
+    params.permit(:priority_pt, :secret).merge(user: current_user, tsundocable_id: tsundocable.id, tsundocable_type: tsundocable.class)
+  end
+
+  def tagging_params
+    params.permit(tag_ids: []).merge(tsundoc_id: @tsundoc.id)
+  end
+
+  def tsundocable
+    @tsundocable || (raise "In TsundocablesController(like a BooksController), you must define Tsundocable instance variable as '@tsundocable'")
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,14 +1,13 @@
 class MoviesController < TsundocsController
+  include TsundocablesControllerModule
+
   def new
     @tsundoc = Tsundoc.new
     @tags = current_user.movie_tags
   end
 
   def create
-    ApplicationRecord.transaction do
-      @tsundocable = Movie.create(movie_params)
-      super
-    end
+    @tsundocable = Movie.create(movie_params)
     redirect_to root_path
   end
 

--- a/app/controllers/tsundocs_controller.rb
+++ b/app/controllers/tsundocs_controller.rb
@@ -14,23 +14,4 @@ class TsundocsController < ApplicationController
   def new
     @tsundoc = Tsundoc.new
   end
-
-  def create
-    @tsundoc = Tsundoc.create(tsundoc_params)
-    @taggings = Tagging.factory(tagging_params[:tag_ids], tagging_params[:tsundoc_id])
-  end
-
-  private
-
-  def tsundoc_params
-    params.permit(:priority_pt, :secret).merge(user: current_user, tsundocable_id: tsundocable.id, tsundocable_type: tsundocable.class)
-  end
-
-  def tagging_params
-    params.permit(tag_ids: []).merge(tsundoc_id: @tsundoc.id)
-  end
-
-  def tsundocable
-    @tsundocable || (raise "In TsundocablesController(like a BooksController), you must define Tsundocable instance variable as '@tsundocable'")
-  end
 end


### PR DESCRIPTION
## why
DRYの手法が適切ではないため
- 積ん読対象コントローラと積ん読コントローラはis-aの関係にない
- 同じロール（生成した本や映画が紐付いた積ん読を生成する役割）を持つためモジュールを用いるのが適切